### PR TITLE
rpc: make the transport type generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,14 @@ keywords = [ "rpc-api", "generic-api-lib", "rpc", "elite-lib", "elite-rpc" ]
 
 
 [dependencies]
-curl = "0.4.44"
 serde_json = "1.0"
 serde = "1.0"
 anyhow = "1.0.81"
 log = "0.4.17"
+curl = {  version = "0.4.44", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9.3"
+
+[features]
+curl = ["dep:curl"]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -21,14 +21,20 @@ pub trait Protocol: Clone {
         Self: Sized;
 
     /// Build the Request for this protocol.
+    ///
+    /// Returning the request to send to the transport and
+    /// also a addons info to the URL.
+    ///
+    /// Like in post there is informtion to add to the base URl.
     fn to_request(
         &self,
         method: &str,
         request: &Self::InnerType,
-    ) -> anyhow::Result<Self::InnerType>;
+    ) -> anyhow::Result<(String, Self::InnerType)>;
 
     /// Build the response fom the response
-    fn from_from_request(
+    #[allow(clippy::wrong_self_convention)]
+    fn from_request(
         &self,
         content: &[u8],
         encoding: Option<Encoding>,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,6 +1,7 @@
 //! Transport trait for JSON RPC like protocol.
 use crate::protocol::Protocol;
 
+#[cfg(feature = "curl")]
 pub mod curl;
 
 /// Transport Method that it is used by the

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -3,6 +3,21 @@ use crate::protocol::Protocol;
 
 pub mod curl;
 
+/// Transport Method that it is used by the
+/// method to build the request.
+pub enum TransportMethod {
+    /// The Http post method, the string inside is the
+    /// url or any other information that can be useful
+    Post(String),
+    /// The http get method, the string inside is the
+    /// url or any other information that can be useful
+    Get(String),
+    /// A custom transport method, e.g: Unix Socket. The
+    /// first string is an simple identifier, and the second is
+    /// a url or a request identifier.
+    Custom(String, String),
+}
+
 /// Communication Transport Layer contract.
 pub trait Transport<P: Protocol> {
     fn new(info: &str, protocol: P) -> anyhow::Result<Self>
@@ -10,5 +25,6 @@ pub trait Transport<P: Protocol> {
         Self: Sized;
 
     /// Perform the call action with the transport layer implemented.
-    fn call(&self, method: &str, request: &P::InnerType) -> anyhow::Result<P::InnerType>;
+    fn call(&self, method: TransportMethod, request: &P::InnerType)
+        -> anyhow::Result<P::InnerType>;
 }


### PR DESCRIPTION
This is make the API a little bit more complex, but it is allow to write Rest protocol that us the HTTP protocols