### PR TITLE
curl: add content type in the curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ARGS=
 TEST_LOG_LEVEL=
 
 default: fmt
-	$(CC) build
+	$(CC) build --all-features
 
 fmt:
 	$(CC) fmt --all

--- a/src/transport/curl.rs
+++ b/src/transport/curl.rs
@@ -41,6 +41,12 @@ impl<P: Protocol> HttpTransport<P> {
         easy.post(true)?;
         easy.post_fields_copy(body)?;
 
+        let mut list = curl::easy::List::new();
+        list.append("Content-Type: application/json")?;
+
+        // Set the content type header
+        easy.http_headers(list)?;
+
         let mut body = Vec::new();
         {
             let mut transfer = easy.transfer();


### PR DESCRIPTION
This is not flexible enough for now because anyone can set the content type that they want.